### PR TITLE
add hashbang

### DIFF
--- a/industrial_reconstruction/nodes/industrial_reconstruction_node.py
+++ b/industrial_reconstruction/nodes/industrial_reconstruction_node.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2022 Southwest Research Institute
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The PR adds a hashbang to the `ros_industrial_node` due to an error at launch.